### PR TITLE
Adding validity check for UUIDs created with NewUUID

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -27,7 +27,7 @@ func (u UUID) Interface() interface{} {
 // NewUUID returns a new, properly instantiated
 // UUID object.
 func NewUUID(u uuid.UUID) UUID {
-	return UUID{UUID: u, Valid: true}
+	return UUID{UUID: u, Valid: u != uuid.Nil}
 }
 
 // Value implements the driver.Valuer interface.

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -23,3 +23,26 @@ func Test_UUID_UnmarshalJSON(t *testing.T) {
 	r.True(nid.Valid)
 	r.Equal(id.String(), nid.UUID.String())
 }
+
+func Test_UUID_NewUUIDValid(t *testing.T) {
+	r := require.New(t)
+	id, err := uuid.NewV4()
+	r.NoError(err)
+
+	nid := NewUUID(id)
+
+	r.True(nid.Valid)
+	r.Equal(id.String(), nid.UUID.String())
+}
+
+func Test_UUID_NewUUIDInvalid(t *testing.T) {
+	r := require.New(t)
+
+	nid := NewUUID(uuid.UUID{})
+
+	r.False(nid.Valid)
+
+	nid = NewUUID(uuid.Nil)
+
+	r.False(nid.Valid)
+}


### PR DESCRIPTION
The validity of an UUID is asserted differently in the implementations of `Scan()` (`uuid.go:44`):
```go
func (u *UUID) Scan(src interface{}) error {
	if src == nil {
		u.UUID, u.Valid = uuid.Nil, false
		return nil
	}

	// ...
}
```
and `NewUUID()` (`uuid.go:30`):
```go
func NewUUID(u uuid.UUID) UUID {
	return UUID{UUID: u, Valid: true}
}
```

`NewUUID()` always sets `u.Valid` to `true`, even if it's an empty `uuid.UUID{}` or `uuid.Nil`.
To ensure consistency between those two functions, `NewUUID()` should check for `uuid.Nil` as well and set `Valid` accordingly.